### PR TITLE
ci の実行条件に main push 時を追加

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - main
 
 jobs:
   lint:


### PR DESCRIPTION
main にキャッシュがないと子ブランチでキャッシュヒットしないため